### PR TITLE
feat: add optional proxy parameter to payload

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ POST following JSON to `http://localhost:8000/scrape`:
 {
 	"url": "http://example.com",
 	"selector": "h1",
-	"hash": "129f2756eac7b62b5b7f428175e5a4e3"
+	"hash": "129f2756eac7b62b5b7f428175e5a4e3",
+	"proxy": "http://localhost:8081"
 }
 ```
 
@@ -60,6 +61,7 @@ Where:
 1. `url` is the URL to fetch.
 1. `selector` is an optional selector. If provided the content will be returned only after this selector returns non-empty elements array. Otherwise the content will be returned on page `onload` event.
 1. `hash` is the request signature done by ``md5(`${url}:${SALT}`)``.
+1. `proxy` is an optional argument to launch chromium with the `--proxy-server` flag
 
 ##### On page load
 

--- a/resources/root/puppeteer-api/index.js
+++ b/resources/root/puppeteer-api/index.js
@@ -33,7 +33,7 @@ app.use(express.json());
  * @param {string} selector See `scrape()`
  * @return {Promise<string>}
  */
-async function securedScrape({url, selector, hash}, sessionId = "local", returnFullPage = false) {
+async function securedScrape({ url, selector, hash, proxy }, sessionId = "local", returnFullPage = false) {
     let myStr = `${url}:${SALT}`;
     let myHash = md5(myStr);
 
@@ -42,7 +42,7 @@ async function securedScrape({url, selector, hash}, sessionId = "local", returnF
         throw [401, 'invalid hash'];
     }
 
-    return await scrape({url, selector}, sessionId, returnFullPage);
+    return await scrape({ url, selector, proxy }, sessionId, returnFullPage);
 }
 
 async function handleRequest(req, res, returnFullPage = false) {

--- a/resources/root/puppeteer-api/puppeteer.js
+++ b/resources/root/puppeteer-api/puppeteer.js
@@ -22,9 +22,8 @@ async function scrape({ url, selector, proxy }, sessionId = "local", returnFullP
         try {
             if (sessionId) console.log(`[${sessionId}]`, 'starting chrome browser');
             const args = ['--no-sandbox', '--disable-gpu'];
-            if (proxy) {
-              args.push(`--proxy-server=${proxy}`)
-            }
+            if (proxy) args.push(`--proxy-server=${proxy}`)
+            
             // see https://github.com/puppeteer/puppeteer/issues/1793#issuecomment-438971272
             const browser = await puppeteer.launch({
                 executablePath: '/usr/bin/chromium-browser',

--- a/resources/root/puppeteer-api/puppeteer.js
+++ b/resources/root/puppeteer-api/puppeteer.js
@@ -16,15 +16,19 @@ const program = require('commander');
  * @param {string} selector CSS selector to check if element appeared, if empty is returns immediately after page is loaded
  * @return {Promise<string>} HTML content after element appeared
  */
-async function scrape({url, selector}, sessionId = "local", returnFullPage = false) {
+async function scrape({ url, selector, proxy }, sessionId = "local", returnFullPage = false) {
 
     return new Promise(async (resolve, reject) => {
         try {
             if (sessionId) console.log(`[${sessionId}]`, 'starting chrome browser');
+            const args = ['--no-sandbox', '--disable-gpu'];
+            if (proxy) {
+              args.push(`--proxy-server=${proxy}`)
+            }
             // see https://github.com/puppeteer/puppeteer/issues/1793#issuecomment-438971272
             const browser = await puppeteer.launch({
-                executablePath: '/usr/bin/chromium-browser',
-                args: ['--no-sandbox', '--disable-gpu']
+                executablePath: '/usr/bin/chromium',
+                args
             });
 
             let j = 0;

--- a/resources/root/puppeteer-api/puppeteer.js
+++ b/resources/root/puppeteer-api/puppeteer.js
@@ -27,7 +27,7 @@ async function scrape({ url, selector, proxy }, sessionId = "local", returnFullP
             }
             // see https://github.com/puppeteer/puppeteer/issues/1793#issuecomment-438971272
             const browser = await puppeteer.launch({
-                executablePath: '/usr/bin/chromium',
+                executablePath: '/usr/bin/chromium-browser',
                 args
             });
 


### PR DESCRIPTION
Hi,

this PR adds proxy support, which can be passed in the body via the `proxy` parameter. It should already be well formatted like: `http://localhost:8118`.

@l0co a review would be greatly appreciated, thank you!